### PR TITLE
Prevent calls to setState on unmounted components.

### DIFF
--- a/src/features/TopMenu/UserMenu/UserMenu.tsx
+++ b/src/features/TopMenu/UserMenu/UserMenu.tsx
@@ -76,6 +76,8 @@ export class UserMenu extends React.Component<PropsWithStylesAndRoutes, State> {
     gravatarUrl: undefined,
   };
 
+  mounted: boolean = false;
+
   handleMenu = (event: React.MouseEvent<HTMLElement>) => {
     this.setState({ anchorEl: event.currentTarget });
   }
@@ -112,9 +114,13 @@ export class UserMenu extends React.Component<PropsWithStylesAndRoutes, State> {
     const instance = Axios.create();
     return instance.get(url)
       .then((response) => {
+        if (!this.mounted) { return; }
+
         this.setState({ gravatarUrl: response.config.url });
       })
       .catch((error) => {
+        if (!this.mounted) { return; }
+
         this.setState({ gravatarUrl: 'not found' });
       });
   }
@@ -132,6 +138,14 @@ export class UserMenu extends React.Component<PropsWithStylesAndRoutes, State> {
       ? <img src={gravatarUrl} className={classes.leftIcon} />
       : <AccountCircle className={classes.leftIcon} />
     );
+  }
+
+  componentDidMount() {
+    this.mounted = true;
+  }
+
+  componentWillUnmount() {
+    this.mounted = false;
   }
 
   render() {

--- a/src/features/TopMenu/UserNotificationMenu/UserNotificationMenu.tsx
+++ b/src/features/TopMenu/UserNotificationMenu/UserNotificationMenu.tsx
@@ -61,12 +61,14 @@ class UserNotificationMenu extends React.Component<CombinedProps, State> {
 
   subscription: Subscription;
 
+  mounted: boolean = false;
+
   static defaultProps = {
     hasNew: false,
   };
 
   componentDidMount() {
-
+    this.mounted = true;
     this.subscription = Observable
       .combineLatest(
         notifications$,
@@ -90,6 +92,8 @@ class UserNotificationMenu extends React.Component<CombinedProps, State> {
       })
       .subscribe(
         ([notifications, events]: [Linode.Notification[], Linode.Event[]]) => {
+          if (!this.mounted) { return; }
+
           this.setState({
             hasNew: hasUnseenEvent(events),
             events,
@@ -114,6 +118,7 @@ class UserNotificationMenu extends React.Component<CombinedProps, State> {
   }
 
   componentWillUnmount() {
+    this.mounted = false;
     this.subscription.unsubscribe();
   }
 

--- a/src/features/Weblish/Weblish.tsx
+++ b/src/features/Weblish/Weblish.tsx
@@ -32,14 +32,20 @@ export class Weblish extends React.Component<CombinedProps, State> {
     renderingLish: true,
   };
 
+  mounted: boolean = false;
+
   getLinode() {
     const { match: { params: { linodeId } } } = this.props;
     Axios.get(`${API_ROOT}/linode/instances/${linodeId}`)
       .then((response) => {
+        if (!this.mounted) { return; }
+
         const { data: linode } = response;
         this.setState({ linode }, this.connect);
       })
       .catch(() => {
+        if (!this.mounted) { return; }
+
         this.setState({ renderingLish: false });
       });
   }
@@ -47,8 +53,13 @@ export class Weblish extends React.Component<CombinedProps, State> {
   componentWillMount() {
     const webLishCss = import('' + '../../assets/weblish/weblish.css');
     const xtermCss = import('' + '../../assets/weblish/xterm.css');
+    this.mounted = false;
     Promise.all([webLishCss, xtermCss])
       .then(() => this.getLinode());
+  }
+
+  componentDidMount() {
+    this.mounted = true;
   }
 
   getLishSchemeAndHostname(region: string): string {

--- a/src/features/linodes/LinodesCreate/LinodesCreate.tsx
+++ b/src/features/linodes/LinodesCreate/LinodesCreate.tsx
@@ -165,6 +165,8 @@ class LinodeCreate extends React.Component<CombinedProps, State> {
     errors: undefined,
   };
 
+  mounted: boolean = false;
+
   handleTabChange = (event: React.ChangeEvent<HTMLDivElement>, value: number) => {
     this.setState({ selectedTab: value });
   }
@@ -226,6 +228,14 @@ class LinodeCreate extends React.Component<CombinedProps, State> {
     },
   ];
 
+  componentDidMount() {
+    this.mounted = true;
+  }
+
+  componentWillUnmount() {
+    this.mounted = false;
+  }
+
   onDeploy = () => {
     const { history } = this.props;
     const {
@@ -252,6 +262,8 @@ class LinodeCreate extends React.Component<CombinedProps, State> {
       history.push('/linodes');
     })
     .catch((error: AxiosError) => {
+      if (!this.mounted) { return; }
+
       this.setState(() => ({
         errors: error.response && error.response.data && error.response.data.errors,
       }));

--- a/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
@@ -204,6 +204,7 @@ const statToColor = {
 
 class LinodeSummary extends React.Component<CombinedProps, State> {
   statsInterval?: number = undefined;
+  mounted: boolean = false;
 
   state: State = {
     stats: undefined,
@@ -254,10 +255,14 @@ class LinodeSummary extends React.Component<CombinedProps, State> {
     }
     req
       .then((response) => {
+        if (!this.mounted) { return; }
+
         this.setState({ statsLoadError: undefined });
         this.setState({ stats: response.data });
       })
       .catch((err) => {
+        if (!this.mounted) { return; }
+
         if (pathOr(undefined, ['response', 'status'], err) === 429) {
           this.setState({ statsLoadError: 'rateLimited' });
         } else {
@@ -268,11 +273,13 @@ class LinodeSummary extends React.Component<CombinedProps, State> {
   }
 
   componentDidMount() {
+    this.mounted = true;
     this.getStats();
     this.statsInterval = window.setInterval(() => this.getStats(), statsFetchInterval);
   }
 
   componentWillUnmount() {
+    this.mounted = false;
     window.clearInterval(this.statsInterval as number);
   }
 

--- a/src/features/linodes/LinodesDetail/LinodesDetail.tsx
+++ b/src/features/linodes/LinodesDetail/LinodesDetail.tsx
@@ -95,6 +95,7 @@ type CombinedProps = Props & PreloadedProps;
 
 class LinodeDetail extends React.Component<CombinedProps, State> {
   subscription: Subscription;
+  mounted: boolean = false;
 
   state = {
     linode: this.props.data.response.linode,
@@ -108,10 +109,12 @@ class LinodeDetail extends React.Component<CombinedProps, State> {
   };
 
   componentWillUnmount() {
+    this.mounted = false;
     this.subscription.unsubscribe();
   }
 
   componentDidMount() {
+    this.mounted = true;
     const mountTime = moment().subtract(5, 'seconds');
     this.subscription = events$
       /* TODO: factor out this filter using a higher-order function that
@@ -120,10 +123,14 @@ class LinodeDetail extends React.Component<CombinedProps, State> {
       .subscribe((linodeEvent) => {
         Axios.get(`${API_ROOT}/linode/instances/${(linodeEvent.entity as Linode.Entity).id}`)
           .then(response => response.data)
-          .then(linode => this.setState(() => {
-            linode.recentEvent = linodeEvent;
-            return { linode };
-          }));
+          .then((linode) => {
+            if (!this.mounted) { return; }
+
+            this.setState(() => {
+              linode.recentEvent = linodeEvent;
+              return { linode };
+            });
+          });
       });
   }
 
@@ -238,13 +245,13 @@ class LinodeDetail extends React.Component<CombinedProps, State> {
           <Route exact path={`${url}/summary`} render={() => (
             <LinodeSummary linode={linode} type={type} image={image} volumes={volumes} />
           )} />
-          <Route exact path={`${url}/volumes`} render={() => (<LinodeVolumes/>)} />
-          <Route exact path={`${url}/networking`} render={() => (<LinodeNetworking/>)} />
-          <Route exact path={`${url}/rescue`} render={() => (<LinodeRescue/>)} />
-          <Route exact path={`${url}/resize`} render={() => (<LinodeResize/>)} />
-          <Route exact path={`${url}/rebuild`} render={() => (<LinodeRebuild/>)} />
-          <Route exact path={`${url}/backup`} render={() => (<LinodeBackup/>)} />
-          <Route exact path={`${url}/settings`} render={() => (<LinodeSettings/>)} />
+          <Route exact path={`${url}/volumes`} render={() => (<LinodeVolumes />)} />
+          <Route exact path={`${url}/networking`} render={() => (<LinodeNetworking />)} />
+          <Route exact path={`${url}/rescue`} render={() => (<LinodeRescue />)} />
+          <Route exact path={`${url}/resize`} render={() => (<LinodeResize />)} />
+          <Route exact path={`${url}/rebuild`} render={() => (<LinodeRebuild />)} />
+          <Route exact path={`${url}/backup`} render={() => (<LinodeBackup />)} />
+          <Route exact path={`${url}/settings`} render={() => (<LinodeSettings />)} />
           {/* 404 */}
           <Route exact render={() => (<Redirect to={`${url}/summary`} />)} />
         </Switch>

--- a/src/features/profile/APITokens/APITokens.tsx
+++ b/src/features/profile/APITokens/APITokens.tsx
@@ -115,6 +115,8 @@ class APITokens extends React.Component<CombinedProps, State> {
     },
   };
 
+  mounted: boolean = false;
+
   state = {
     pats: pathOr([], ['response', 'data'], this.props.pats),
     ...APITokens.defaultState,
@@ -217,7 +219,11 @@ class APITokens extends React.Component<CombinedProps, State> {
   requestTokens = () => {
     Axios.get(`${API_ROOT}/profile/tokens`)
     .then(response => response.data.data)
-    .then(data => this.setState({ pats: data }));
+    .then((data) => {
+      if (!this.mounted) { return; }
+
+      return this.setState({ pats: data });
+    });
   }
 
   openCreateDrawer = () => {
@@ -309,6 +315,8 @@ class APITokens extends React.Component<CombinedProps, State> {
       })
       .then(() => this.requestTokens())
       .catch((errResponse) => {
+        if (!this.mounted) { return; }
+
         this.setState({ form: {
           ...form,
           errors: path(['response', 'data', 'errors'], errResponse),
@@ -323,11 +331,21 @@ class APITokens extends React.Component<CombinedProps, State> {
     .then(() => { this.closeDrawer(); })
     .then(() => this.requestTokens())
     .catch((errResponse) => {
+      if (!this.mounted) { return; }
+
       this.setState({ form: {
         ...form,
         errors: path(['response', 'data', 'errors'], errResponse),
       }});
     });
+  }
+
+  componentDidMount() {
+    this.mounted = true;
+  }
+
+  componentWillUnmount() {
+    this.mounted = false;
   }
 
   render() {

--- a/src/features/profile/OAuthClients/OAuthClients.tsx
+++ b/src/features/profile/OAuthClients/OAuthClients.tsx
@@ -91,6 +91,8 @@ class OAuthClients extends React.Component<CombinedProps, State> {
     },
   };
 
+  mounted: boolean = false;
+
   state = {
     data: this.props.data.response,
     ...OAuthClients.defaultState,
@@ -111,7 +113,11 @@ class OAuthClients extends React.Component<CombinedProps, State> {
   requestClients = () => {
     Axios.get(apiPath)
       .then(response => response.data.data)
-      .then(data => this.setState({ data }));
+      .then((data) => {
+        if (!this.mounted) { return; }
+
+        return this.setState({ data });
+      });
   }
 
   deleteClient = (id: string) => {
@@ -122,7 +128,9 @@ class OAuthClients extends React.Component<CombinedProps, State> {
   resetSecret = (id: string) => {
     Axios.post(`${apiPath}/${id}/reset-secret`)
       .then(({ data: { secret } }) => {
-        this.setState({ secret: { open: true, value: secret } });
+        if (!this.mounted) { return; }
+
+        return this.setState({ secret: { open: true, value: secret } });
       });
   }
 
@@ -141,7 +149,9 @@ class OAuthClients extends React.Component<CombinedProps, State> {
     const { form: { values } } = this.state;
     Axios.post(apiPath, values)
       .then((response) => {
-        this.setState({
+        if (!this.mounted) { return; }
+
+        return this.setState({
           secret: { value: response.data.secret, open: true },
           form: {
             open: false,
@@ -155,9 +165,13 @@ class OAuthClients extends React.Component<CombinedProps, State> {
         });
       })
       .then((response) => {
+        if (!this.mounted) { return; }
+
         this.requestClients();
       })
       .catch((errResponse) => {
+        if (!this.mounted) { return; }
+
         this.setForm(form => ({
           ...form,
           errors: path(['response', 'data', 'errors'], errResponse),
@@ -203,6 +217,14 @@ class OAuthClients extends React.Component<CombinedProps, State> {
         </TableCell>
       </TableRow>
     ));
+  }
+
+  componentDidMount() {
+    this.mounted = true;
+  }
+
+  componentWillUnmount() {
+    this.mounted = false;
   }
 
   render() {


### PR DESCRIPTION
## Purpose
I found a number of instances throughout the code base, including your PR, that don't prevent calls to setState on unmounted components. I've used the instance variable mounted pattern we've seen previously to prevent this.